### PR TITLE
feat: add inspect endpoint for function names and tests suite for that

### DIFF
--- a/dapp/src/index.ts
+++ b/dapp/src/index.ts
@@ -19,7 +19,7 @@ const governance = new Governance([INITIAL_DAO_MEMBER]);
 const validatorManager = ValidatorManager.getInstance();
 
 advanceHandlers(app, wallet , appManager, governance, validatorManager);
-const router = inspectHandlers(app, wallet, appManager, governance);
+const router = inspectHandlers(app, wallet, appManager, governance, validatorManager);
 app.addInspectHandler(router.handler);
 app.start().catch((error) => {
     console.error("Failed to start the application:", error);

--- a/dapp/src/inspect/functions.ts
+++ b/dapp/src/inspect/functions.ts
@@ -1,0 +1,7 @@
+import { InspectHandlers } from ".";
+
+export const register: InspectHandlers = ({ router, validatorManager }) => {
+    router.add("functions/getAllFunctionNames", () => {
+        return JSON.stringify(validatorManager?.getAllFunctionNames());
+    })
+};

--- a/dapp/src/inspect/index.ts
+++ b/dapp/src/inspect/index.ts
@@ -11,15 +11,19 @@ export type InspectHandlerInput = {
   router: Router;
   appManager: AppManager;
   governance: Governance;
+  validatorManager?: ValidatorManager;
 };
 
 export type InspectHandlers = (args:InspectHandlerInput) => void;
 
 import * as gamesRoutes from "./games";
 import * as governanceRoutes from "./governance";
-import { Hex } from "viem";
+import * as functions from "./functions";
 
-export default (app: App, wallet: WalletApp , appManager: AppManager, governance:Governance) => {
+import { Hex } from "viem";
+import { ValidatorManager } from "../validator";
+
+export default (app: App, wallet: WalletApp , appManager: AppManager, governance:Governance, validatorManager: ValidatorManager) => {
   const router = createRouter({ app });
 
   router.add<{ sender: string }>(
@@ -42,6 +46,7 @@ export default (app: App, wallet: WalletApp , appManager: AppManager, governance
 
   gamesRoutes.register({app, wallet, router, appManager, governance});
   governanceRoutes.register({app, wallet, router, appManager, governance});
+  functions.register({ app, wallet, router, appManager, governance, validatorManager });
 
   return router;
 };

--- a/dapp/src/validator.ts
+++ b/dapp/src/validator.ts
@@ -35,6 +35,10 @@ export class ValidatorManager {
         return this.functions.entries();
     }
 
+    getAllFunctionNames(): string[] {
+        return Array.from(this.functions.keys());
+    }
+
 }
 
 // It takes a string with a JS function and 

--- a/dapp/test/validator.test.ts
+++ b/dapp/test/validator.test.ts
@@ -11,10 +11,10 @@ import { Bet, VFR } from "../src/types";
 describe("ValidatorFunctionRunner", () => {
     const privateTestKey = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
     const publicTestKey = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
-    let wallet: WalletClient
-    let account: PrivateKeyAccount
-    let governance: Governance
-    let checker: DAOSignatureBlobChecker
+    let wallet: WalletClient;
+    let account: PrivateKeyAccount;
+    let governance: Governance;
+    let checker: DAOSignatureBlobChecker;
 
     beforeAll(() => {
         account = privateKeyToAccount(privateTestKey);
@@ -125,29 +125,42 @@ describe('ValidatorManager', () => {
     });
 
     test('should create a new validator', () => {
-        manager.createNewValidator('test_validator', testValidatorFunction);
-        expect(manager.functions).length(1);
+        manager.createNewValidator('test_validator', `async (...args) => 'test_result'`);
+        expect(manager.functions.size).toBe(1);
     });
 
     test('should get an existing validator', () => {
-        manager.createNewValidator('existing_validator', testValidatorFunction);
+        manager.createNewValidator('existing_validator', `async (...args) => 'test_result'`);
         const validator = manager.getValidator('existing_validator');
         expect(validator).not.toBeNull();
     });
 
     test('should list all validators', () => {
         const validators = new Map([
-            ['validator1', testValidatorFunction],
-            ['validator2', async () => 'validator2_result'],
+            ['validator1', `async (...args) => 'validator1_result'`],
+            ['validator2', `async (...args) => 'validator2_result'`],
         ]);
 
         // Adding multiple validators
         validators.forEach((fn, name) => {
-            manager.createNewValidator(name, testValidatorFunction);
+            manager.createNewValidator(name, fn);
         });
 
         const listedValidators = Array.from(manager.getValidators());
 
-        expect(listedValidators).length(validators.size);
+        expect(listedValidators.length).toBe(validators.size);
+    });
+
+    test('should get all function names', () => {
+        const validators = ['validator1', 'validator2'];
+
+        // Adding multiple validators
+        validators.forEach(name => {
+            manager.createNewValidator(name, `async (...args) => '${name}_result'`);
+        });
+
+        const functionNames = manager.getAllFunctionNames();
+
+        expect(functionNames).toEqual(validators);
     });
 });


### PR DESCRIPTION
# Brief
We needed an endpoint that lists all function names we have registered.

## Activities
- Implementation of the endpoint
- Test suites for generated functions in the validator manager

## Evidences

Endpoint route:
![image](https://github.com/Mugen-Builders/memebet-backend/assets/4421825/38a1677f-4dca-4231-abcb-c17b02bb811c)

Endpoint response when
![image](https://github.com/Mugen-Builders/memebet-backend/assets/4421825/78feb75d-e27f-49e7-9ce6-dc1dafd4229a)

Translation
![image](https://github.com/Mugen-Builders/memebet-backend/assets/4421825/768fdd11-729e-4da8-8332-6e2d5ffad259)
